### PR TITLE
Update commit.bat to use relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Dodge-the-Slippers
 First 2D game
+
+## Helper scripts
+
+`commit.bat` is a convenience script for Windows users. It adds all files,
+creates a commit and pushes to the `main` branch. Run it from anywhere, or pass
+an optional commit message:
+
+```bat
+commit.bat "My commit message"
+```
+
+The script uses relative paths so it works as long as it resides inside the
+repository.

--- a/commit.bat
+++ b/commit.bat
@@ -1,14 +1,19 @@
 @echo off
-cd /d "C:\Users\Alexe\Documents\Godot\Projects\Dodge the Slippers"
+REM Change to the directory where this script resides
+cd /d "%~dp0"
 
-echo Добавляем все файлы...
+echo Adding all files...
 git add .
 
-echo Создаем коммит...
-git commit -m "Новая версия проекта"
+REM Use the first argument as the commit message if provided
+set MESSAGE=%1
+if "%MESSAGE%"=="" set MESSAGE=Update project
 
-echo Отправляем на GitHub...
+echo Creating commit...
+git commit -m "%MESSAGE%"
+
+echo Pushing to GitHub...
 git push origin main
 
-echo Готово!
+echo Done!
 pause


### PR DESCRIPTION
## Summary
- make `commit.bat` portable by removing the hard-coded path
- document `commit.bat` in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b763f59f48325a60f2c9539e6e0f6